### PR TITLE
add prometheus-exporter role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: damex
 name: prometheus
-version: 1.1.1
+version: 1.2.0
 readme: README.md
 authors:
   - Roman Kuzmitskii <ansible@damex.org>

--- a/roles/prometheus_exporter/defaults/main.yml
+++ b/roles/prometheus_exporter/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+prometheus_exporter_name: ""
+prometheus_exporter_variable_prefix: "{{ prometheus_exporter_name | regex_replace('-', '_') }}"
+prometheus_exporter_state: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_state', default='present') }}"
+prometheus_exporter_package_name: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_package_name', default=prometheus_exporter_name) }}"
+prometheus_exporter_package_version: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_package_version', default='') }}"
+prometheus_exporter_package_state: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_package_state', default=prometheus_exporter_state) }}"
+prometheus_exporter_service_name: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_service_name', default=prometheus_exporter_name) }}"
+prometheus_exporter_default_configuration_directory: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_default_configuration_directory', default='/etc/default') }}"
+prometheus_exporter_default_configuration_file: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_default_configuration_file', default=prometheus_exporter_name) }}"
+prometheus_exporter_environment_variables: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_environment_variables', default='{}') }}"
+prometheus_exporter_configuration_arguments: "{{ lookup('vars', prometheus_exporter_variable_prefix + '_configuration_arguments', default='[]') }}"

--- a/roles/prometheus_exporter/meta/argument_specs.yml
+++ b/roles/prometheus_exporter/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    options:
+      prometheus_exporter_name:
+        type: str
+        required: true
+      prometheus_exporter_state:
+        type: str
+        required: false
+        default: present
+        choices:
+          - absent
+          - present
+      prometheus_exporter_environment_variables:
+        type: dict
+        required: false
+      prometheus_exporter_configuration_arguments:
+        type: list
+        required: false
+        elements: str

--- a/roles/prometheus_exporter/meta/main.yml
+++ b/roles/prometheus_exporter/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Roman Kuzmitskii <ansible@damex.org>
+  description: prometheus exporter role
+  license: GPLv2
+  min_ansible_version: 2.14.2
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+    - name: Ubuntu
+      versions:
+        - focal
+dependencies: []

--- a/roles/prometheus_exporter/tasks/configuration.yml
+++ b/roles/prometheus_exporter/tasks/configuration.yml
@@ -1,0 +1,10 @@
+---
+- name: Ensure prometheus exporter default configuration file
+  ansible.builtin.template:
+    src: prometheus-exporter.default.j2
+    dest: "{{ prometheus_exporter_default_configuration_directory }}/{{ prometheus_exporter_default_configuration_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  register: prometheus_exporter_default_configuration_file_state

--- a/roles/prometheus_exporter/tasks/main.yml
+++ b/roles/prometheus_exporter/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Ensure prometheus exporter
+  tags:
+    - prometheus
+    - prometheus_exporter
+  block:
+    - name: Ensure prometheus exporter package
+      ansible.builtin.import_tasks: package.yml
+    - name: Ensure prometheus exporter configuration
+      ansible.builtin.import_tasks: configuration.yml
+    - name: Ensure prometheus exporter systemd
+      ansible.builtin.import_tasks: systemd.yml

--- a/roles/prometheus_exporter/tasks/package.yml
+++ b/roles/prometheus_exporter/tasks/package.yml
@@ -1,0 +1,9 @@
+---
+- name: Ensure prometheus exporter package
+  ansible.builtin.include_role:
+    name: damex.apt.apt_packages
+  vars:
+    apt_packages:
+      - name: "{{ prometheus_exporter_package_name }}"
+        version: "{{ prometheus_exporter_package_version }}"
+        state: "{{ prometheus_exporter_package_state }}"

--- a/roles/prometheus_exporter/tasks/systemd.yml
+++ b/roles/prometheus_exporter/tasks/systemd.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure prometheus exporter systemd service
+  ansible.builtin.include_role:
+    name: damex.systemd.systemd_service
+  vars:
+    systemd_service_name: "{{ prometheus_exporter_service_name }}"
+    systemd_service_restart_on: "{{ prometheus_exporter_default_configuration_file_state.changed }}"

--- a/roles/prometheus_exporter/templates/prometheus-exporter.default.j2
+++ b/roles/prometheus_exporter/templates/prometheus-exporter.default.j2
@@ -1,0 +1,6 @@
+{{ ansible_managed | comment }}
+
+{% for prometheus_exporter_environment_variable_key, prometheus_exporter_environment_variable_value in prometheus_exporter_environment_variables.items() %}
+{{ prometheus_exporter_environment_variable_key }}="{{ prometheus_exporter_environment_variable_value }}"
+{% endfor %}
+ARGS="{{ prometheus_exporter_configuration_arguments | join (' ') }}"


### PR DESCRIPTION
Create a prometheus-exporter role that can manage arbitrary exporters.
The role uses variables from the inventory based on the exporter name.

For example, if the exporter package name is prometheus-node-exporter, the role will use variables like prometheus_node_exporter_package_name, prometheus_exporter_environment_variables, and prometheus_node_exporter_configuration_arguments.

The role also pulls a ‘defaults’ configuration file that contains environment variables and command arguments for the exporter.
These are used by the prometheus-exporter systemd unit, such as prometheus-node-exporter in this case.